### PR TITLE
fix for blended header for striped tabs

### DIFF
--- a/client/templates/tabs/_tabsHeader.html
+++ b/client/templates/tabs/_tabsHeader.html
@@ -1,6 +1,13 @@
 <template name="_tabsHeader">
-  {{#ionHeaderBar class="bar-positive"}}
-    {{>ionNavBackButton path="index"}}
-    <h1 class="title">Tabs</h1>
-  {{/ionHeaderBar}}
+  {{#if isAndroid}}
+    {{#ionHeaderBar class="bar-positive has-tabs-top"}}
+      {{>ionNavBackButton path="index"}}
+        <h1 class="title">Tabs</h1>
+    {{/ionHeaderBar}}
+  {{else}}
+    {{#ionHeaderBar class="bar-positive"}}
+      {{>ionNavBackButton path="index"}}
+        <h1 class="title">Tabs</h1>
+    {{/ionHeaderBar}}
+  {{/if}}
 </template>


### PR DESCRIPTION
header will not blend with striped tabs on top without has-tabs-top for android
refer to http://ionicframework.com/docs/components/#striped-style-tabs
